### PR TITLE
Webwork: add exercises to section 0.1

### DIFF
--- a/project.ptx
+++ b/project.ptx
@@ -10,7 +10,10 @@
       <format>html</format>
       <source>source/main.ptx</source>
       <publication>publication/publication.ptx</publication>
-      <output-dir>output/web</output-dir>
+      <output-dir>output/web</output-dir>      
+      <!-- Webwork exercises are non-interactive by default -->
+      <!-- We disable this behavior -->
+      <stringparam key="webwork.divisional.static" value="no"/>
     </target>
     <target name="print" pdf-method="xelatex">
       <format>pdf</format>
@@ -33,6 +36,10 @@
       <!-- edit this to change the section/chapter/etc. to include
            in your subset build -->
       <xmlid-root>c_foundations</xmlid-root>
+      <!-- Webwork exercises are non-interactive by default -->
+      <!-- We disable this behavior -->
+      <stringparam key="webwork.divisional.static" value="no"/>
+
     </target>
   </targets>
   <executables>

--- a/source/s_sets_functions.ptx
+++ b/source/s_sets_functions.ptx
@@ -490,4 +490,7 @@
     </proof>
 
 </subsection>
+
+<xi:include href="s_sets_functions_ex.ptx"/>
+
 </section>

--- a/source/s_sets_functions_ex.ptx
+++ b/source/s_sets_functions_ex.ptx
@@ -1,34 +1,23 @@
 <exercises xml:id="s_sets_functions_ex">
   <exercise>
-  <!-- 1. union of sets -->
-    <webwork source="Library/SDSU/Discrete/Sets/unionB3.pg" />
+  <!-- 1. union and intersections of sets -->
+    <webwork source="Library/ASU-topics/setSets/ur_st_1_2.pg" />
   </exercise>
   <exercise>
-  <!-- 2. intersection of sets -->
-    <webwork source="Library/SDSU/Discrete/Sets/intersectA2.pg" />
+  <!-- 2. products of sets -->
+    <webwork source="Library/SDSU/Discrete/Sets/cartesianprodB4.pg" />
   </exercise>
   <exercise>
-  <!-- 3. difference of sets -->
-    <webwork source="Library/SDSU/Discrete/Sets/differenceB4.pg" />
-  </exercise>
-  <exercise>
-  <!-- 4. products of sets -->
-    <webwork source="Library/Rochester/setSetTheory1/ur_st_1_7.pg" />
-  </exercise>
-  <exercise>
-  <!-- 5. integer subsets -->
-    <webwork source="Library/SDSU/Discrete/Sets/subsetB3.pg" />
-  </exercise> 
-  <exercise>
-  <!-- 6. image of intervals under a function -->
+  <!-- 3. image of intervals under a function -->
     <webwork source="Library/MontanaState/Sets/5.2A13Sets1.pg" />
   </exercise>
   <exercise>
-  <!-- 7. one-to-one and onto -->
+  <!-- 4. one-to-one and onto -->
     <webwork source="Library/SUNYSB/oneToOneOnto1.pg" />
   </exercise>
   <exercise>
-  <!-- 8. inverses -->
+  <!-- 5. inverses -->
     <webwork source="Library/LoyolaChicago/Precalc/Chap8Sec2/Q08.pg" />
   </exercise>
+  <!-- No exercises on set differences. -->
 </exercises>

--- a/source/s_sets_functions_ex.ptx
+++ b/source/s_sets_functions_ex.ptx
@@ -1,0 +1,34 @@
+<exercises xml:id="s_sets_functions_ex">
+  <exercise>
+  <!-- 1. union of sets -->
+    <webwork source="Library/SDSU/Discrete/Sets/unionB3.pg" />
+  </exercise>
+  <exercise>
+  <!-- 2. intersection of sets -->
+    <webwork source="Library/SDSU/Discrete/Sets/intersectA2.pg" />
+  </exercise>
+  <exercise>
+  <!-- 3. difference of sets -->
+    <webwork source="Library/SDSU/Discrete/Sets/differenceB4.pg" />
+  </exercise>
+  <exercise>
+  <!-- 4. products of sets -->
+    <webwork source="Library/Rochester/setSetTheory1/ur_st_1_7.pg" />
+  </exercise>
+  <exercise>
+  <!-- 5. integer subsets -->
+    <webwork source="Library/SDSU/Discrete/Sets/subsetB3.pg" />
+  </exercise> 
+  <exercise>
+  <!-- 6. image of intervals under a function -->
+    <webwork source="Library/MontanaState/Sets/5.2A13Sets1.pg" />
+  </exercise>
+  <exercise>
+  <!-- 7. one-to-one and onto -->
+    <webwork source="Library/SUNYSB/oneToOneOnto1.pg" />
+  </exercise>
+  <exercise>
+  <!-- 8. inverses -->
+    <webwork source="Library/LoyolaChicago/Precalc/Chap8Sec2/Q08.pg" />
+  </exercise>
+</exercises>


### PR DESCRIPTION
Webwork exercises for section 0.1: https://apurvnakade.github.io/nulib-oer-linear-algebra/s_sets_functions.html#s_sets_functions_ex

Only "fill in the blanks" type exercises work on Pretext. I removed the previous set of exercises with checkmarks and added in new ones.

Let me know if you have any suggestions. I'm not sure I should add any description to the start of the section. 