### PR TITLE
Webwork: add webwork exercises to chapter 1

### DIFF
--- a/project.ptx
+++ b/project.ptx
@@ -35,7 +35,7 @@
       <stringparam key="debug.skip-knowls" value="yes"/>
       <!-- edit this to change the section/chapter/etc. to include
            in your subset build -->
-      <xmlid-root>c_foundations</xmlid-root>
+      <xmlid-root>c_linear_systems</xmlid-root>
       <!-- Webwork exercises are non-interactive by default -->
       <!-- We disable this behavior -->
       <stringparam key="webwork.divisional.static" value="no"/>

--- a/source/s_solving_ex.ptx
+++ b/source/s_solving_ex.ptx
@@ -1,109 +1,115 @@
 <exercises xml:id="s_solving_ex">
+
 <subexercises>
+  <!-- 1. solve a system of equations in 4 variables -->
   <exercise>
-    <webwork source="Library/TCNJ/TCNJ_RowReduction/problem8.pg" />
-  </exercise>
-  <exercise>
-    <webwork source="Library/TCNJ/TCNJ_RowReduction/problem10.pg" />
-  </exercise>
-  <exercise>
-    <webwork source="Library/TCNJ/TCNJ_RowReduction/problem3.pg" />
+    <webwork source="Library/Utah/Business_Algebra/set11_Inequalities_and_Linear_Programming/p02.pg" />
   </exercise>
 </subexercises>
 
 <exercisegroup>
-<introduction>
-<p>Solve the following systems of equations.
-<ul>
-  <li>
-    <p>
-      When row reducing follow Gaussian elimination to the letter.
-    </p>
-  </li>
-  <li>
-    <p>
-      Make sure to indicate how variables are sorted into free and leading variables.
-    </p>
-  </li>
-  <li>
-    <p>
-      Express your answer in both the parametric equation format and set notation format.
-    </p>
-  </li>
-</ul>
-</p>
-</introduction>
-<exercise>
-  <statement>
-    <p>
-      <me>
-        \begin{linsys}{4} x_1\amp +\amp 2x_2\amp =\amp x_3\amp +\amp x_4\amp +\amp 3\\ 3x_1\amp +\amp 6x_2\amp =\amp 2x_3\amp -\amp 4x_4\amp +\amp 8\\ -x_1\amp +\amp 2x_3\amp =\amp 2x_2\amp -\amp x_4\amp -\amp 1 \end{linsys}
-      </me>
-    </p>
-  </statement>
-  <solution>
-    <p>
-    We saw in <xref ref="s_ge_equivsys"/> that the system is equivalent to a system <m>L'</m> with augmented matrix
-    <me>
-    \begin{amatrix}[rrrr|r]\boxed{1}\amp 2\amp -1\amp -1\amp 3\\ 0\amp 0\amp \boxed{1}\amp 7\amp -1\\ 0\amp 0\amp 0\amp \boxed{1}\amp -\frac{3}{7} \end{amatrix}
-    </me>.
-    The row echelon matrix tells us that <m>x_2=t</m> is the only free variable of <m>L'</m>. Back substitution then yields the parametric equation description:
-    <md>
-      <mrow>x_1\amp = \frac{32}{7}-2t</mrow>
-      <mrow>x_2\amp = t</mrow>
-      <mrow>x_3\amp = 2</mrow>
-      <mrow>x_4\amp = -\frac{3}{7}</mrow>
-    </md>.
-    Thus the set of solutions is
-    <me>
-      \left\{ \left(\frac{32}{7}-2t, t, 2, -\frac{3}{7}\right)\colon t\in \R\right\}
-    </me>.
+  <introduction>
+  <p>Solve the following systems of equations.
+  <ul>
+    <li>
+      <p>
+        When row reducing follow Gaussian elimination to the letter.
+      </p>
+    </li>
+    <li>
+      <p>
+        Make sure to indicate how variables are sorted into free and leading variables.
+      </p>
+    </li>
+    <li>
+      <p>
+        Express your answer in both the parametric equation format and set notation format.
+      </p>
+    </li>
+  </ul>
   </p>
-  </solution>
-</exercise>
-
-<exercise>
-  <statement>
-    <p>
-      <me>\begin{linsys}{4} x_1\amp +\amp x_2\amp -\amp x_3\amp +\amp x_4\amp =\amp 1\\ -2x_1\amp -\amp 2x_2\amp +\amp 2x_3\amp -\amp 2x_4\amp =\amp -2\\ x_1\amp +\amp x_2\amp +\amp x_3\amp +\amp 2x_4\amp =\amp 3 \end{linsys}
-      </me>
-    </p>
-  </statement>
-
-</exercise>
-<exercise>
-  <statement>
-    <p>
+  </introduction>
+  <exercise>
+    <statement>
+      <p>
+        <me>
+          \begin{linsys}{4} x_1\amp +\amp 2x_2\amp =\amp x_3\amp +\amp x_4\amp +\amp 3\\ 3x_1\amp +\amp 6x_2\amp =\amp 2x_3\amp -\amp 4x_4\amp +\amp 8\\ -x_1\amp +\amp 2x_3\amp =\amp 2x_2\amp -\amp x_4\amp -\amp 1 \end{linsys}
+        </me>
+      </p>
+    </statement>
+    <solution>
+      <p>
+      We saw in <xref ref="s_ge_equivsys"/> that the system is equivalent to a system <m>L'</m> with augmented matrix
       <me>
-        \begin{linsys}{3} 2x_1 \amp +\amp  2x_2  \amp +\amp 2x_3\amp =\amp 0\\ -2x_1 \amp +\amp  5x_2 \amp +\amp 2x_3\amp =\amp 1\\ 8x_1 \amp +\amp   x_2   \amp +\amp 4x_3\amp =\amp -1 \end{linsys}
-      </me>
-    </p>
-  </statement>
-
-</exercise>
-<exercise>
-  <statement>
-    <p>
+      \begin{amatrix}[rrrr|r]\boxed{1}\amp 2\amp -1\amp -1\amp 3\\ 0\amp 0\amp \boxed{1}\amp 7\amp -1\\ 0\amp 0\amp 0\amp \boxed{1}\amp -\frac{3}{7} \end{amatrix}
+      </me>.
+      The row echelon matrix tells us that <m>x_2=t</m> is the only free variable of <m>L'</m>. Back substitution then yields the parametric equation description:
+      <md>
+        <mrow>x_1\amp = \frac{32}{7}-2t</mrow>
+        <mrow>x_2\amp = t</mrow>
+        <mrow>x_3\amp = 2</mrow>
+        <mrow>x_4\amp = -\frac{3}{7}</mrow>
+      </md>.
+      Thus the set of solutions is
       <me>
-        \begin{linsys}{3} \amp \amp -2b  \amp +\amp 3c\amp =\amp 1\\ 3a \amp +\amp  6b \amp -\amp 3c\amp =\amp -2\\ 6a \amp +\amp   6b   \amp +\amp 3c\amp =\amp 5 \end{linsys}
-      </me>
-
+        \left\{ \left(\frac{32}{7}-2t, t, 2, -\frac{3}{7}\right)\colon t\in \R\right\}
+      </me>.
     </p>
-  </statement>
+    </solution>
+  </exercise>
 
-</exercise>
-<exercise>
-  <statement>
-    <p>
-      <me>
-        \begin{linsys}{5} \amp  \amp  \amp \amp  T_3\amp +\amp T_4\amp +\amp T_5 \amp =\amp 0\\ -T_1\amp -\amp T_2 \amp +\amp 2T_3 \amp -\amp 3T_4\amp +\amp T_5 \amp =\amp 0\\ T_1\amp + \amp T_2 \amp -\amp 2T_3 \amp \amp \amp -\amp T_5 \amp =\amp 0\\ 2T_1\amp + \amp 2T_2 \amp -\amp T_3 \amp \amp \amp +\amp T_5 \amp =\amp 0 \end{linsys}
-      </me>
+  <exercise>
+    <statement>
+      <p>
+        <me>\begin{linsys}{4} x_1\amp +\amp x_2\amp -\amp x_3\amp +\amp x_4\amp =\amp 1\\ -2x_1\amp -\amp 2x_2\amp +\amp 2x_3\amp -\amp 2x_4\amp =\amp -2\\ x_1\amp +\amp x_2\amp +\amp x_3\amp +\amp 2x_4\amp =\amp 3 \end{linsys}
+        </me>
+      </p>
+    </statement>
 
-    </p>
-  </statement>
+  </exercise>
+  <exercise>
+    <statement>
+      <p>
+        <me>
+          \begin{linsys}{3} 2x_1 \amp +\amp  2x_2  \amp +\amp 2x_3\amp =\amp 0\\ -2x_1 \amp +\amp  5x_2 \amp +\amp 2x_3\amp =\amp 1\\ 8x_1 \amp +\amp   x_2   \amp +\amp 4x_3\amp =\amp -1 \end{linsys}
+        </me>
+      </p>
+    </statement>
 
-</exercise>
+  </exercise>
+  <exercise>
+    <statement>
+      <p>
+        <me>
+          \begin{linsys}{3} \amp \amp -2b  \amp +\amp 3c\amp =\amp 1\\ 3a \amp +\amp  6b \amp -\amp 3c\amp =\amp -2\\ 6a \amp +\amp   6b   \amp +\amp 3c\amp =\amp 5 \end{linsys}
+        </me>
+
+      </p>
+    </statement>
+
+  </exercise>
+  <exercise>
+    <statement>
+      <p>
+        <me>
+          \begin{linsys}{5} \amp  \amp  \amp \amp  T_3\amp +\amp T_4\amp +\amp T_5 \amp =\amp 0\\ -T_1\amp -\amp T_2 \amp +\amp 2T_3 \amp -\amp 3T_4\amp +\amp T_5 \amp =\amp 0\\ T_1\amp + \amp T_2 \amp -\amp 2T_3 \amp \amp \amp -\amp T_5 \amp =\amp 0\\ 2T_1\amp + \amp 2T_2 \amp -\amp T_3 \amp \amp \amp +\amp T_5 \amp =\amp 0 \end{linsys}
+        </me>
+
+      </p>
+    </statement>
+
+  </exercise>
+
 </exercisegroup>
+
+
+<subexercises>
+  <exercise>
+    <!-- 7. Systems of equations in 3 variables -->
+    <webwork source="Library/TCNJ/TCNJ_LinearSystems/problem17.pg" />
+  </exercise>
+</subexercises>
+
 <exercise>
   <statement>
     <p>

--- a/source/s_solving_ex.ptx
+++ b/source/s_solving_ex.ptx
@@ -1,4 +1,16 @@
 <exercises xml:id="s_solving_ex">
+<subexercises>
+  <exercise>
+    <webwork source="Library/TCNJ/TCNJ_RowReduction/problem8.pg" />
+  </exercise>
+  <exercise>
+    <webwork source="Library/TCNJ/TCNJ_RowReduction/problem10.pg" />
+  </exercise>
+  <exercise>
+    <webwork source="Library/TCNJ/TCNJ_RowReduction/problem3.pg" />
+  </exercise>
+</subexercises>
+
 <exercisegroup>
 <introduction>
 <p>Solve the following systems of equations.

--- a/source/s_systems_ex.ptx
+++ b/source/s_systems_ex.ptx
@@ -13,10 +13,6 @@
       <!-- 3. System of equations in 3 variables -->
       <webwork source="Library/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_024.pg" />
     </exercise>
-    <exercise>
-      <!-- 4. Systems of equations in 3 variables -->
-      <webwork source="Library/TCNJ/TCNJ_LinearSystems/problem17.pg" />
-    </exercise>
   </subsexercises>
 
   <exercise xml:id="ex_solving_sys_geom">
@@ -172,11 +168,11 @@
 
   <subsexercises>
     <exercise>
-      <!-- 6. Geometry in 2 variables -->
+      <!-- 5. Geometry in 2 variables -->
       <webwork source="Library/TCNJ/TCNJ_LinearSystems/problem3.pg" />
     </exercise>
     <exercise>
-      <!-- 7. Geometry in 3 variables -->      
+      <!-- 6. Geometry in 3 variables -->      
       <webwork source="Library/TCNJ/TCNJ_LinearSystems/problem4.pg" />
     </exercise>
   </subsexercises>

--- a/source/s_systems_ex.ptx
+++ b/source/s_systems_ex.ptx
@@ -1,7 +1,33 @@
 <exercises xml:id="s_systems_ex">
+  
+  <subsexercises>
+    <exercise>
+      <webwork source="Library/TCNJ/TCNJ_LinearSystems/problem1.pg" />
+    </exercise>
+    <exercise>
+    <!-- 1.  -->
+      <webwork source="Library/TCNJ/TCNJ_RowReduction/problem5.pg" />
+    </exercise>
+    <exercise>
+    <!-- 1.  -->
+      <webwork source="Library/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_024.pg" />
+    </exercise>
+    <exercise>
+      <webwork source="Library/TCNJ/TCNJ_LinearSystems/problem17.pg" />
+    </exercise>
+   <!-- <exercise>
+      <webwork source="Library/TCNJ/TCNJ_RowReduction/problem8.pg" />
+    </exercise>
+    <exercise>
+      <webwork source="Library/TCNJ/TCNJ_RowReduction/problem10.pg" />
+    </exercise>
+    <exercise>
+      <webwork source="Library/TCNJ/TCNJ_RowReduction/problem3.pg" />
+    </exercise>  -->
+  </subsexercises>
+
   <exercise xml:id="ex_solving_sys_geom">
     <title>Geometry of linear systems</title>
-
     <statement>
       <p>
         Recall that the <em>graph</em> of an equation is the set of all solutions to the equation. Graphs of linear equations correspond to some familiar geometric objects:
@@ -150,6 +176,16 @@
       </p>
     </solution>
   </exercise>
+
+  <subsexercises>
+    <exercise>
+      <webwork source="Library/TCNJ/TCNJ_LinearSystems/problem3.pg" />
+    </exercise>
+    <exercise>
+      <webwork source="Library/TCNJ/TCNJ_LinearSystems/problem4.pg" />
+    </exercise>
+  </subsexercises>
+
   <exercise xml:id="ex_row_ops_preserve">
     <title>Row operations preserve solutions</title>
     <statement>

--- a/source/s_systems_ex.ptx
+++ b/source/s_systems_ex.ptx
@@ -2,28 +2,21 @@
   
   <subsexercises>
     <exercise>
+      <!-- 1. Systems of equations in 2 variables -->
       <webwork source="Library/TCNJ/TCNJ_LinearSystems/problem1.pg" />
     </exercise>
     <exercise>
-    <!-- 1.  -->
+      <!-- 2. System of equations in 2 variable with unknown constant -->
       <webwork source="Library/TCNJ/TCNJ_RowReduction/problem5.pg" />
     </exercise>
     <exercise>
-    <!-- 1.  -->
+      <!-- 3. System of equations in 3 variables -->
       <webwork source="Library/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_024.pg" />
     </exercise>
     <exercise>
+      <!-- 4. Systems of equations in 3 variables -->
       <webwork source="Library/TCNJ/TCNJ_LinearSystems/problem17.pg" />
     </exercise>
-   <!-- <exercise>
-      <webwork source="Library/TCNJ/TCNJ_RowReduction/problem8.pg" />
-    </exercise>
-    <exercise>
-      <webwork source="Library/TCNJ/TCNJ_RowReduction/problem10.pg" />
-    </exercise>
-    <exercise>
-      <webwork source="Library/TCNJ/TCNJ_RowReduction/problem3.pg" />
-    </exercise>  -->
   </subsexercises>
 
   <exercise xml:id="ex_solving_sys_geom">
@@ -179,9 +172,11 @@
 
   <subsexercises>
     <exercise>
+      <!-- 6. Geometry in 2 variables -->
       <webwork source="Library/TCNJ/TCNJ_LinearSystems/problem3.pg" />
     </exercise>
     <exercise>
+      <!-- 7. Geometry in 3 variables -->      
       <webwork source="Library/TCNJ/TCNJ_LinearSystems/problem4.pg" />
     </exercise>
   </subsexercises>


### PR DESCRIPTION
I've added exercises to Chapter 1.1 and Chapter 1.3:
https://apurvnakade.github.io/nulib-oer-linear-algebra/s_systems.html#s_systems_ex 
https://apurvnakade.github.io/nulib-oer-linear-algebra/s_solving.html#s_solving_ex

Pretext is not able to render problems involving matrices :( It throws an error saying that the Pretext is unable to convert the problem to XML. My guess is that Pretext cannot yet convert Webwork problems involving \begin{bmatrix} ... \end{matrix}. Because of this there aren't any compatible problems for Chapters 1.2. I'm worried that there would not be any problems for the next chapter which involve matrices (rank, nullity, determinant). I suggest that we make matrix problems on Sage. I can help out with that if you have any preferences on the type of questions.

The NU Webwork server keeps crashing everytime I search for problems :( I have been using a combination of Edfinity, [Libretext](https://query.libretexts.org/Community_Gallery/WeBWorK_Assessments/Linear_algebra), and the [Github OPL repo](https://github.com/openwebwork/webwork-open-problem-library) to browse problems. 
