### PR TITLE
Webwork: Add more exercises to chapter 1

### DIFF
--- a/source/s_ge_ex.ptx
+++ b/source/s_ge_ex.ptx
@@ -57,6 +57,20 @@
   </solution> -->
 </exercise>
 </exercisegroup>
+
+<subexercises>
+<title>Webwork Exercises</title>
+<exercise>
+  <!-- Individual row reductions for a 3x3 matrix -->
+  <webwork source="Library/Mizzou/Finite_Math/MatrixOperations/RowOp3by3e.pg" />
+</exercise>
+
+<exercise>
+  <!-- Combined row reductions for a 3x3 matrix -->
+  <webwork source="Library/ASU-topics/set119LinearSystems/p28.pg" />
+</exercise>
+</subexercises>
+
 <exercisegroup>
 <introduction>
   For each of the given linear systems, find an equivalent system in row echelon form. Use augmented matrices and follow the Gaussian elimination algorithm to the letter.

--- a/source/s_solving_ex.ptx
+++ b/source/s_solving_ex.ptx
@@ -3,13 +3,20 @@
 <subexercises>
   <title>WeBWork Exercises</title>
 
-
-  <!-- 1. solve a system of equations in 4 variables -->
   <exercise>
-    <webwork source="Library/Utah/Business_Algebra/set11_Inequalities_and_Linear_Programming/p02.pg" />
+  <!-- 1. steps for solving a system of equations in 2 variables -->
+    <webwork source="Library/Mizzou/Finite_Math/Augmented_Matrices/AugMatrix1a.pg" />
   </exercise>
 
-
+  <exercise>
+  <!-- 2. steps for solving a system of equations in 3 variables -->
+    <webwork source="Library/Mizzou/Finite_Math/Gauss-Jordan_Elimination/3by3a.pg" />
+  </exercise>
+  
+  <exercise>
+  <!-- 3. solve a system of equations in 4 variables -->
+    <webwork source="Library/Utah/Business_Algebra/set11_Inequalities_and_Linear_Programming/p02.pg" />
+  </exercise>
 
 </subexercises>
 


### PR DESCRIPTION
I found a few more webwork exercises for Chapter 1 that were compatible with Pretext.

[Exercise 5](https://apurvnakade.github.io/nulib-oer-linear-algebra/s_ge.html#exercise-31) 
https://apurvnakade.github.io/nulib-oer-linear-algebra/s_ge.html#exercise-31

[Exercise 6](https://apurvnakade.github.io/nulib-oer-linear-algebra/s_ge.html#exercise-32) 
https://apurvnakade.github.io/nulib-oer-linear-algebra/s_ge.html#exercise-32

[Exercise 1](https://apurvnakade.github.io/nulib-oer-linear-algebra/s_solving.html#exercise-38) 
https://apurvnakade.github.io/nulib-oer-linear-algebra/s_solving.html#exercise-38

[Exercise 2](https://apurvnakade.github.io/nulib-oer-linear-algebra/s_solving.html#exercise-39) 
https://apurvnakade.github.io/nulib-oer-linear-algebra/s_solving.html#exercise-39